### PR TITLE
Extend available options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,52 @@
 [![Build Status](https://secure.travis-ci.org/componitable/format-number.png)](http://travis-ci.org/componitable/format-number)
 # format-number
- 
+
+Highly configurable formatter that expects a valid number in 'computer' format and accepts the following as options for formatting
+
+## Options
+- `negativeType` string: 'right','left','brackets','none'; default = 'left' (note only used for setting of default symbols)
+- `negativeLeftSymbol` string: default = '-' if `negativeType` is 'left', '(' if `negativeType` is 'brackets' and '' otherwise
+- `negativeRightSymbol` string: default = '-' if `negativeType` is 'right', ')' if `negativeType` is 'brackets' and '' otherwise
+- `negativeLeftOut` boolean: whether the left symbol should be outside, ie precede the prefix; default = true
+- `negativeLeftOut` boolean: whether the left symbol should be outside, ie precede the prefix; default = true
+- `prefix` string: default = ''
+- `suffix` string: default = ''
+- `integerSeparator` string: to be used as the thousands separator; default = ','
+- `decimalsSeparator` string: to be used as the thousanths separator; default = ''
+- `decimal` string: char to be used as decimal point; default = '.'
+- `padLeft` number: leading 0s will be added to left of number to make integer part this length; default = -1 /no padding
+- `padRight` number: trailing 0s will be added; default = -1 /no padding
+- `round` number: number of decimal places to round to (rounds to nearest integer, mid point rounds away from zero ie 3.55 ~ 3.6 to 1dp, -3.55 ~ -3.6 to 1dp; default = no rounding
+- `truncate` number: number of decimal places to truncate (3.58 truncates to 3.5 for 1dp, 3 for 0dp); default =  no truncating
+
+## additional parameters
+includeUnits - defaults to true, if false will override and leave out prefix and suffix
+separate - defaults to true, if false will override both integer and decimals separator and leave them out
+
+## Use
+```
+var format=require('format-number');
+var formattedNumber = format({prefix: '£', suffix: '/item'})(68932, true, false);
+```
+or
+```
+var format=require('format-number');
+var myFormat = format({prefix: '£', suffix: '/item'});
+var formattedNumber = myFormat(68932, true, false);
+```
+will both set formattedNumber to '£68932/item'
+
+Note that the additional parameters are optional so 
+```
+var format=require('format-number');
+var formattedNumber = format({prefix: '£', suffix: '/item'})(68932);
+```
+returns '£68,932/item'
+
+
+
+# Examples
+
 <a name="defaults" />
 ## defaults
 <a name="defaults-512" />

--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ Highly configurable formatter that expects a valid number in 'computer' format a
 - `negativeLeftSymbol` string: default = '-' if `negativeType` is 'left', '(' if `negativeType` is 'brackets' and '' otherwise
 - `negativeRightSymbol` string: default = '-' if `negativeType` is 'right', ')' if `negativeType` is 'brackets' and '' otherwise
 - `negativeLeftOut` boolean: whether the left symbol should be outside, ie precede the prefix; default = true
-- `negativeLeftOut` boolean: whether the left symbol should be outside, ie precede the prefix; default = true
+- `negativeRightOut` boolean: whether the right symbol should be outside, ie follow the suffix; default = true
 - `prefix` string: default = ''
 - `suffix` string: default = ''
 - `integerSeparator` string: to be used as the thousands separator; default = ','

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function formatter(options) {
     }
     
     //Format core number
-    number = number.split(options.decimal);
+    number = number.split('.');
     if (options.round != null) round(number, options.round);
     if (options.truncate != null) number[1] = truncate(number[1], options.truncate);
     if (options.padLeft > 0) number[0] = padLeft(number[0], options.padLeft);

--- a/index.js
+++ b/index.js
@@ -47,12 +47,19 @@ function formatter(options) {
   if (typeof options.negativeRightOut !== "boolean") {
     options.negativeRightOut = (options.negativeOut === false ? false : true);
   }
+  
+  //prefix and suffix
   options.prefix = options.prefix || '';
   options.suffix = options.suffix || '';
-  options.integerSeparator = typeof options.integerSeparator === 'string' ? options.separator : ',';
-  options.integerSeparator = typeof options.integerSeparator === 'string' ? options.integerSeparator : ',';
+  
+  //separators
+  if (typeof options.integerSeparator !== 'string') {
+    options.integerSeparator = (typeof options.separator === 'string' ? options.separator : ',');
+  }
   options.decimalsSeparator = typeof options.decimalsSeparator === 'string' ? options.decimalsSeparator : '';
   options.decimal = options.decimal || '.';
+  
+  //padders
   options.padLeft = options.padLeft || -1 //default no padding
   options.padRight = options.padRight || -1 //default no padding
 

--- a/index.js
+++ b/index.js
@@ -88,8 +88,8 @@ function formatter(options) {
     if (options.truncate != null) number[1] = truncate(number[1], options.truncate);
     if (options.padLeft > 0) number[0] = padLeft(number[0], options.padLeft);
     if (options.padRight > 0) number[1] = padRight(number[1], options.padRight);
-    if (options.decimalsSeparator.length) number[1] = addDecimalSeparators(number[0], options.decimalsSeparator);
-    if (separate) number[0] = addIntegerSeparators(number[0], options.integerSeparator);
+    if (separate && number[1]) number[1] = addDecimalSeparators(number[1], options.decimalsSeparator);
+    if (separate && number[0]) number[0] = addIntegerSeparators(number[0], options.integerSeparator);
     output.push(number[0]);
     if (number[1]) {
       output.push(options.decimal);

--- a/index.js
+++ b/index.js
@@ -4,12 +4,52 @@ module.exports = formatter;
 function formatter(options) {
   options = options || {};
 
-  //Set defaults
-  options.negative = options.negative === 'R' ? 'R' : 'L';
-  options.negativeOut = options.negativeOut === false ? false : true;
+
+  // *********************************************************************************************
+  // Set defaults for negatives
+  // options.negative, options.negativeOut, options.separator retained for backward compatibility
+  // *********************************************************************************************
+
+  // type of negative; default left
+  options.negativeType = options.negativeType || (options.negative === 'R' ? 'right' : 'left')
+
+  // negative symbols '-' or '()'
+  if (typeof options.negativeLeftSymbol !== 'string') {
+    switch (options.negativeType) {
+      case 'left':
+        options.negativeLeftSymbol = '-';
+        break;
+      case 'brackets':
+        options.negativeLeftSymbol = '(';
+        break;
+      default:
+        options.negativeLeftSymbol = '';
+    }
+  }
+  if (typeof options.negativeRightSymbol !== 'string') {
+    switch (options.negativeType) {
+      case 'right':
+        options.negativeRightSymbol = '-';
+        break;
+      case 'brackets':
+        options.negativeRightSymbol = ')';
+        break;
+      default:
+        options.negativeRightSymbol = '';
+    }
+  }
+
+  // whether negative symbol should be inside/outside prefix and suffix
+
+  if (typeof options.negativeLeftOut !== "boolean") {
+    options.negativeLeftOut = (options.negativeOut === false ? false : true);
+  }
+  if (typeof options.negativeRightOut !== "boolean") {
+    options.negativeRightOut = (options.negativeOut === false ? false : true);
+  }
   options.prefix = options.prefix || '';
   options.suffix = options.suffix || '';
-  options.integerSeparator = options.integerSeparator || options.separator; //included for backward compatibility
+  options.integerSeparator = typeof options.integerSeparator === 'string' ? options.separator : ',';
   options.integerSeparator = typeof options.integerSeparator === 'string' ? options.integerSeparator : ',';
   options.decimalsSeparator = typeof options.decimalsSeparator === 'string' ? options.decimalsSeparator : '';
   options.decimal = options.decimal || '.';
@@ -32,13 +72,13 @@ function formatter(options) {
     number = number.replace(/^\-/g, '');
 
     //Prepare output with left hand negative and/or prefix
-    if (!options.negativeOut && includeUnits) {
+    if (!options.negativeLeftOut && includeUnits) {
       output.push(options.prefix);
     }
-    if (negative && options.negative === 'L') {
-      output.push('-');
+    if (negative) {
+      output.push(options.negativeLeftSymbol);
     }
-    if (options.negativeOut && includeUnits) {
+    if (options.negativeLeftOut && includeUnits) {
       output.push(options.prefix);
     }
     
@@ -57,13 +97,13 @@ function formatter(options) {
     }
 
     //Prepare output with right hand negative and/or prefix
-    if (options.negativeOut && includeUnits) {
+    if (options.negativeRightOut && includeUnits) {
       output.push(options.suffix);
     }
-    if (negative && options.negative === 'R') {
-      output.push('-');
+    if (negative) {
+      output.push(options.negativeRightSymbol);
     }
-    if (!options.negativeOut && includeUnits) {
+    if (!options.negativeRightOut && includeUnits) {
       output.push(options.suffix);
     }
 
@@ -73,6 +113,11 @@ function formatter(options) {
 
   format.negative = options.negative;
   format.negativeOut = options.negativeOut;
+  format.negativeType = options.negativeType;
+  format.negativeLeftOut = options.negativeLeftOut;
+  format.negativeLeftSymbol = options.negativeLeftSymbol;
+  format.negativeRightOut = options.negativeRightOut;
+  format.negativeRightSymbol = options.negativeRightSymbol;
   format.prefix = options.prefix;
   format.suffix = options.suffix;
   format.separate = options.separate;

--- a/index.js
+++ b/index.js
@@ -9,14 +9,19 @@ function formatter(options) {
   options.separator = typeof options.separator === 'string' ? options.separator : ',';
   options.decimal = options.decimal || '.';
   
+  options.padLeft = options.padLeft || -1 //default no padding
+  options.padRight = options.padRight || -1 //default no padding
+
   function format(number, includeUnits, separate) {
     includeUnits = includeUnits === false ? false : true;
     separate = separate === false ? false : true;
+
     if (number || number === 0) {
       number = '' + number;//convert number to string if it isn't already
     } else {
       return '';
     }
+
     var output = [];
     var negative = number.charAt(0) === '-';
     number = number.replace(/^\-/g, '');
@@ -34,9 +39,9 @@ function formatter(options) {
     number = number.split(options.decimal);
     if (options.round != null) round(number, options.round);
     if (options.truncate != null) number[1] = truncate(number[1], options.truncate);
-    if (options.padLeft) number[0] = padLeft(number[0], options.padLeft);
-    if (options.padRight) number[1] = padRight(number[1], options.padRight);
     if (separate) number[0] = addSeparators(number[0], options.separator);
+    if (options.padLeft > 0) number[0] = padLeft(number[0], options.padLeft);
+    if (options.padRight > 0) number[1] = padRight(number[1], options.padRight);
     output.push(number[0]);
     if (number[1]) {
       output.push(options.decimal);

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 var expect = require('expect.js');
 var formatFactory = require('..');
 
+//Defaults
 describe('defaults', function () {
   var format = formatFactory();
   describe('512', function () {
@@ -35,6 +36,7 @@ describe('defaults', function () {
   });
 });
 
+//padRight=2
 describe('padRight=2', function () {
   var format = formatFactory({padRight: 2});
   describe('512', function () {
@@ -59,6 +61,7 @@ describe('padRight=2', function () {
   });
 });
 
+//truncate=2
 describe('truncate=2', function () {
   var format = formatFactory({truncate: 2});
   describe('512', function () {
@@ -83,6 +86,7 @@ describe('truncate=2', function () {
   });
 });
 
+//round=2
 describe('round=2', function () {
   var format = formatFactory({round: 2});
   describe('512', function () {
@@ -112,6 +116,7 @@ describe('round=2', function () {
   });
 });
 
+//round=0
 describe('round=0', function () {
   var format = formatFactory({round: 0});
   describe('512', function () {
@@ -136,6 +141,7 @@ describe('round=0', function () {
   });
 });
 
+//prefix
 describe('prefix=£', function () {
   var format = formatFactory({prefix: '£'});
   describe('512', function () {
@@ -167,6 +173,7 @@ describe('prefix=£', function () {
   });
 });
 
+//suffix
 describe('suffix=" items"', function () {
   var format = formatFactory({suffix: ' items'});
   describe('512', function () {
@@ -203,3 +210,243 @@ describe('suffix=" items"', function () {
     });
   });
 });
+
+//negativeType
+describe('negativeType="brackets"', function () {
+  var format = formatFactory({negativeType: 'brackets'});
+  describe('512', function () {
+    it('returns 512', function () {
+      expect(format('512')).to.be('512');
+    });
+  });
+  describe('-512', function () {
+    it('returns (512)', function () {
+      expect(format('-512')).to.be('(512)');
+    });
+  });
+});
+describe('negativeType="right"', function () {
+  var format = formatFactory({negativeType: 'right'});
+  describe('512', function () {
+    it('returns 512', function () {
+      expect(format('512')).to.be('512');
+    });
+  });
+  describe('-512', function () {
+    it('returns 512-', function () {
+      expect(format('-512')).to.be('512-');
+    });
+  });
+});
+describe('negativeType="left"', function () {
+  var format = formatFactory({negativeType: 'left'});
+  describe('512', function () {
+    it('returns 512', function () {
+      expect(format('512')).to.be('512');
+    });
+  });
+  describe('-512', function () {
+    it('returns -512', function () {
+      expect(format('-512')).to.be('-512');
+    });
+  });
+});
+//negative for backward compatibility
+describe('negative="R"', function () {
+  var format = formatFactory({negative: 'R'});
+  describe('512', function () {
+    it('returns 512', function () {
+      expect(format('512')).to.be('512');
+    });
+  });
+  describe('-512', function () {
+    it('returns 512-', function () {
+      expect(format('-512')).to.be('512-');
+    });
+  });
+});
+describe('negative="L"', function () {
+  var format = formatFactory({negative: 'L'});
+  describe('512', function () {
+    it('returns 512', function () {
+      expect(format('512')).to.be('512');
+    });
+  });
+  describe('-512', function () {
+    it('returns -512', function () {
+      expect(format('-512')).to.be('-512');
+    });
+  });
+});
+
+
+//negative....Out
+describe('negativeLeftOut"', function () {
+  var format = formatFactory({negativeType: 'brackets', prefix: '£', suffix: '/item', 
+                              negativeLeftOut: true, negativeRightOut: false});
+  describe('512', function () {
+    it('returns £512/item', function () {
+      expect(format('512')).to.be('£512/item');
+    });
+  });
+  describe('512', function () {
+    it('returns (£512)/item', function () {
+      expect(format('-512')).to.be('(£512)/item');
+    });
+  });
+});
+describe('negativeRightOut"', function () {
+  var format = formatFactory({negativeType: 'brackets', prefix: '£', suffix: '/item', 
+                              negativeLeftOut: false, negativeRightOut: true});
+  describe('512', function () {
+    it('returns £512/item', function () {
+      expect(format('512')).to.be('£512/item');
+    });
+  });
+  describe('512', function () {
+    it('returns £(512/item)', function () {
+      expect(format('-512')).to.be('£(512/item)');
+    });
+  });
+});
+describe('negativeLeftOut and negativeRightOut both true"', function () {
+  var format = formatFactory({negativeType: 'brackets', prefix: '£', suffix: '/item', 
+                              negativeLeftOut: true, negativeRightOut: true});
+  describe('512', function () {
+    it('returns £512/item', function () {
+      expect(format('512')).to.be('£512/item');
+    });
+  });
+  describe('512', function () {
+    it('returns (£512/item)', function () {
+      expect(format('-512')).to.be('(£512/item)');
+    });
+  });
+});
+describe('negativeLeftOut and negativeRightOut both false"', function () {
+  var format = formatFactory({negativeType: 'brackets', prefix: '£', suffix: '/item', 
+                              negativeLeftOut: false, negativeRightOut: false});
+  describe('512', function () {
+    it('returns £512/item', function () {
+      expect(format('512')).to.be('£512/item');
+    });
+  });
+  describe('512', function () {
+    it('returns £(512)/item', function () {
+      expect(format('-512')).to.be('£(512)/item');
+    });
+  });
+});
+//backward compatibility with negativeOut
+describe('backward compatibility with negativeOut true"', function () {
+  var format = formatFactory({negativeType: 'brackets', prefix: '£', suffix: '/item', 
+                              negativeOut: true});
+  describe('512', function () {
+    it('returns £512/item', function () {
+      expect(format('512')).to.be('£512/item');
+    });
+  });
+  describe('512', function () {
+    it('returns (£512/item)', function () {
+      expect(format('-512')).to.be('(£512/item)');
+    });
+  });
+});
+describe('backward compatibility with negativeOut false"', function () {
+  var format = formatFactory({negativeType: 'brackets', prefix: '£', suffix: '/item', 
+                              negativeOut: false});
+  describe('512', function () {
+    it('returns £512/item', function () {
+      expect(format('512')).to.be('£512/item');
+    });
+  });
+  describe('512', function () {
+    it('returns £(512)/item', function () {
+      expect(format('-512')).to.be('£(512)/item');
+    });
+  });
+});
+
+//separators
+describe('integerSeparator = " "', function () {
+  var format = formatFactory({integerSeparator: " "});
+  describe('5123423.1234567', function () {
+    it('returns 5 123 423.1234567', function () {
+      expect(format('5123423.1234567')).to.be('5 123 423.1234567');
+    });
+  });
+  describe('with separate as false', function () {
+    describe('5123423.1234567', function () {
+      it('returns 5123423.1234567', function () {
+        expect(format('5123423.1234567', true, false)).to.be('5123423.1234567');
+      });
+    });
+  });
+});
+describe('decimalsSeparator = " "', function () {
+  var format = formatFactory({integerSeparator: "", decimalsSeparator: " "});
+  describe('5123423.1234567', function () {
+    it('returns 5123423.123 456 7', function () {
+      expect(format('5123423.1234567')).to.be('5123423.123 456 7');
+    });
+  });
+  describe('with separate as false', function () {
+    describe('5123423.1234567', function () {
+      it('returns 5123423.1234567', function () {
+        expect(format('5123423.1234567', true, false)).to.be('5123423.1234567');
+      });
+    });
+  });
+});
+//for backwards compatibility
+describe('separator = " "', function () {
+  var format = formatFactory({separator: " "});
+  describe('5123423.1234567', function () {
+    it('returns 5 123 423.1234567', function () {
+      expect(format('5123423.1234567')).to.be('5 123 423.1234567');
+    });
+  });
+  describe('with separate as false', function () {
+    describe('5123423.1234567', function () {
+      it('returns 5123423.1234567', function () {
+        expect(format('5123423.1234567', true, false)).to.be('5123423.1234567');
+      });
+    });
+  });
+});
+
+//decimal
+describe('decimal = "."', function () {
+  var format = formatFactory({integerSeparator: " ", decimal:"."});
+  describe('5123423.1234567', function () {
+    it('returns 5 123 423.1234567', function () {
+      expect(format('5123423.1234567')).to.be('5 123 423.1234567');
+    });
+  });
+});
+describe('decimal = ","', function () {
+  var format = formatFactory({integerSeparator: " ", decimal:","});
+  describe('5123423.1234567', function () {
+    it('returns 5 123 423,1234567', function () {
+      expect(format('5123423.1234567')).to.be('5 123 423,1234567');
+    });
+  });
+});
+
+//miscellaneous
+describe('£68,932/item', function () {
+  it('£68,932/item', function () {
+    expect(formatFactory({prefix: '£', suffix: '/item'})(68932)).to.be('£68,932/item');
+  });
+});
+describe('£68,932/items with no units', function () {
+  it('68,932', function () {
+    expect(formatFactory({prefix: '£', suffix: '/item'})(68932, false)).to.be('68,932');
+  });
+});
+describe('£68,932/items with no separators', function () {
+  it('£68932/item', function () {
+    expect(formatFactory({prefix: '£', suffix: '/item'})(68932, true, false)).to.be('£68932/item');
+  });
+});
+


### PR DESCRIPTION
This request extends existing parameters to allow
 - separators of the decimal part of the number
 - brackets as negative markers
 - negativeOut to be controlled separately for left and right markers
I have kept these changes to work alongside the old options so this part is backward compatible

The other change that I have made is to expect the input decimal char to be ".".
This is on the basis that the input should be unformatted "computer" format. 

I've also written lots of tests to both check some of the existing functionality and the new. 

FYI My plan is to create another 'project' to use deconstruct-number-format  to pass parameters to this
