### PR TITLE
Fix bug with decimal seperator not being `.`

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function formatter(options) {
   options.suffix = options.suffix || '';
   options.separator = typeof options.separator === 'string' ? options.separator : ',';
   options.decimal = options.decimal || '.';
-  
+
   function format(number, includeUnits, separate) {
     includeUnits = includeUnits === false ? false : true;
     separate = separate === false ? false : true;
@@ -31,7 +31,7 @@ function formatter(options) {
       output.push(options.prefix);
     }
 
-    number = number.split(options.decimal);
+    number = number.split('.');
     if (options.round != null) round(number, options.round);
     if (options.truncate != null) number[1] = truncate(number[1], options.truncate);
     if (options.padLeft) number[0] = padLeft(number[0], options.padLeft);

--- a/test/index.js
+++ b/test/index.js
@@ -184,7 +184,7 @@ describe('suffix=" items"', function () {
       expect(format('')).to.be('');
     });
   });
-  
+
   describe('with includeUnits as false', function () {
     describe('512', function () {
       it('returns 512', function () {
@@ -203,3 +203,22 @@ describe('suffix=" items"', function () {
     });
   });
 });
+
+describe('decimal=, separator=.', function() {
+  var format = formatFactory({decimal: ',', separator: '.'});
+  describe('512', function() {
+    it('returns 512', function() {
+      expect(format('512')).to.be('512')
+    })
+  })
+  describe('1024', function() {
+    it('returns 1.024', function() {
+      expect(format('1024')).to.be('1.024')
+    })
+  })
+  describe('512.4', function() {
+    it('returns 512,4', function() {
+      expect(format('512.4')).to.be('512,4')
+    })
+  })
+})


### PR DESCRIPTION
When parsing numbers to add separators the previous code assumed the input
number to formatted with the same decimal separator as was intended in the
output, however this did not work for input of Number and a decimal separator
different from `.`. Since the code already implicitly assumes Numbers for
separator formatting (existing separators are not stripped), it is safe to
assume the decimal separator of input to always be `.`