### PR TITLE
decimalsSeparator, installation and syntax highlight

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Highly configurable formatter that expects a valid number in 'computer' format a
 - `prefix` string: default = ''
 - `suffix` string: default = ''
 - `integerSeparator` string: to be used as the thousands separator; default = ','
-- `decimalsSeparator` string: to be used as the thousanths separator; default = ''
+- `decimalsSeparator` string: to be used as the decimal separator; default = '.'
 - `decimal` string: char to be used as decimal point; default = '.'
 - `padLeft` number: leading 0s will be added to left of number to make integer part this length; default = -1 /no padding
 - `padRight` number: trailing 0s will be added; default = -1 /no padding

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,9 @@
 
 Highly configurable formatter that expects a valid number in 'computer' format and accepts the following as options for formatting
 
+## Installation
+`npm install format-number`
+
 ## Options
 
 - `negativeType` string: 'right','left','brackets','none'; default = 'left' (note only used for setting of default symbols)
@@ -27,15 +30,15 @@ Highly configurable formatter that expects a valid number in 'computer' format a
 
 ## Usage
 
-```
-var format=require('format-number');
+```javascript
+var format = require('format-number');
 var formattedNumber = format({prefix: '£', suffix: '/item'})(68932, {noSeparator: true});
 ```
 
 or
 
-```
-var format=require('format-number');
+```javascript
+var format = require('format-number');
 var myFormat = format({prefix: '£', suffix: '/item'});
 var formattedNumber = myFormat(68932, {noSeparator: true});
 ```
@@ -44,8 +47,8 @@ will both set formattedNumber to '£68932/item'
 
 The override options can be ommitted:
 
-```
-var format=require('format-number');
+```javascript
+var format = require('format-number');
 var formattedNumber = format({prefix: '£', suffix: '/item'})(68932);
 ```
 


### PR DESCRIPTION
- Looks like `decimalsSeparator` description is just copied from `integerSeparator`
- Add NPM install instruction
- Format code and add JavaScript Markdown syntax