### PR TITLE
Show negative number as zero without negative symbol

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,17 @@ function formatter(options) {
     var negative = number.charAt(0) === '-';
     number = number.replace(/^\-/g, '');
 
+    //Format core number
+    number = number.split('.');
+    if (options.round != null) round(number, options.round);
+    if (options.truncate != null) number[1] = truncate(number[1], options.truncate);
+    if (options.padLeft > 0) number[0] = padLeft(number[0], options.padLeft);
+    if (options.padRight > 0) number[1] = padRight(number[1], options.padRight);
+    if (!overrideOptions.noSeparator && number[1]) number[1] = addDecimalSeparators(number[1], options.decimalsSeparator);
+    if (!overrideOptions.noSeparator && number[0]) number[0] = addIntegerSeparators(number[0], options.integerSeparator);
+
+    negative = negative && Number(number.join('.')) !== 0;
+
     //Prepare output with left hand negative and/or prefix
     if (!options.negativeLeftOut && !overrideOptions.noUnits) {
       output.push(options.prefix);
@@ -89,14 +100,6 @@ function formatter(options) {
       output.push(options.prefix);
     }
 
-    //Format core number
-    number = number.split('.');
-    if (options.round != null) round(number, options.round);
-    if (options.truncate != null) number[1] = truncate(number[1], options.truncate);
-    if (options.padLeft > 0) number[0] = padLeft(number[0], options.padLeft);
-    if (options.padRight > 0) number[1] = padRight(number[1], options.padRight);
-    if (!overrideOptions.noSeparator && number[1]) number[1] = addDecimalSeparators(number[1], options.decimalsSeparator);
-    if (!overrideOptions.noSeparator && number[0]) number[0] = addIntegerSeparators(number[0], options.integerSeparator);
     output.push(number[0]);
     if (number[1]) {
       output.push(options.decimal);

--- a/test/index.js
+++ b/test/index.js
@@ -420,6 +420,19 @@ describe('backward compatibility with negativeOut false"', function () {
   });
 });
 
+//zero without negative symbol
+describe('always show zero without negative symbol', function () {
+  it('positive zero', function () {
+    expect(formatFactory({round: 2})('0.0000123')).to.be('0.00');
+  });
+  it('exactly zero', function () {
+    expect(formatFactory({round: 2})('0.0000000')).to.be('0.00');
+  });
+  it('negative zero', function () {
+    expect(formatFactory({round: 2})('-0.0000123')).to.be('0.00');
+  });
+});
+
 //separators
 describe('integerSeparator = " "', function () {
   var format = formatFactory({integerSeparator: " "});


### PR DESCRIPTION
If we take a negative number and format it as zero, we shouldn't show a negative symbol.
For example, -0.000123 should be formatted as "0.00" and not as "-0.00".